### PR TITLE
display dense to avoid holes in the grid

### DIFF
--- a/public/photo-grid.css
+++ b/public/photo-grid.css
@@ -4,6 +4,8 @@
 
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   grid-auto-rows: 240px;
+  
+  grid-auto-flow: dense;
 }
 
 /* Medium screens */


### PR DESCRIPTION
hey @codediodeio, you could probably include `grid-auto-flow: dense;` to avoid having holes in the gallery, for example if you remove the first 3 images you can see something like this:
http://recordit.co/NETNEk6Fix

but using `grid-auto-flow: dense;`:
http://recordit.co/2eIfqBBjNV

(even though if it's not the best for accessibility because of the changes in the order of the cards)
Thanks for your great content!