### PR TITLE
refactor: remove unnecessary auto grid-*-end

### DIFF
--- a/public/photo-grid.css
+++ b/public/photo-grid.css
@@ -9,10 +9,10 @@
 /* Medium screens */
 @media screen and (min-width: 600px) {
   .card-tall {
-    grid-row: span 2 / auto;
+    grid-row: span 2;
   }
 
   .card-wide {
-    grid-column: span 2 / auto;
+    grid-column: span 2;
   }
 }


### PR DESCRIPTION
Since default value for `grid-row-end` and `grid-column-end` is `auto`, it's safe to remove them for cleaner code.